### PR TITLE
Modernize geokit-geoip

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "http://rubygems.org"
 gemspec
 
-gem 'debugger'
+gem 'byebug'

--- a/geokit-geoip.gemspec
+++ b/geokit-geoip.gemspec
@@ -4,7 +4,7 @@ $:.unshift lib unless $:.include?(lib)
 
 Gem::Specification.new do |s|
   s.name = 'geokit-geoip'
-  s.version = '0.1.0'
+  s.version = '1.0.0'
 
   s.authors = ["Aaron Suggs"]
   s.description = "Our GeoKit module for using a local (proprietary) Maxmind GeoIP database"

--- a/geokit-geoip.gemspec
+++ b/geokit-geoip.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |s|
   s.test_files = Dir.glob("test/**/*")
 
   s.add_dependency 'geoip'
-  s.add_dependency 'geokit', '>= 1.5.0' # What we're using on kickstarter at the moment
+  s.add_dependency 'geokit', '>= 1.10.0' # What we're using on kickstarter at the moment
   s.add_development_dependency 'rake'
   s.add_development_dependency 'shoulda'
+  s.add_development_dependency 'minitest'
 end

--- a/lib/geokit-geoip.rb
+++ b/lib/geokit-geoip.rb
@@ -6,7 +6,7 @@ require 'geoip'
 module Geokit
   module Geocoders
 
-    @@geoip_data_path = File.expand_path(File.join(File.dirname(__FILE__),'..','data','GeoLiteCity.dat')) 
+    @@geoip_data_path = File.expand_path(File.join(File.dirname(__FILE__),'..','data','GeoLiteCity.dat'))
     __define_accessors
 
     # Provide geocoding based upon an IP address.  The underlying web service is maxmind.com.
@@ -38,4 +38,3 @@ module Geokit
     end
   end
 end
-

--- a/test/test_geokit_geoip.rb
+++ b/test/test_geokit_geoip.rb
@@ -1,6 +1,6 @@
 require File.dirname(__FILE__) + '/test_helper.rb'
 
-class TestGeokitGeoip < Test::Unit::TestCase
+class TestGeokitGeoip < MiniTest::Test
 
   context "GeoIpCityGeocoder" do
     setup do
@@ -42,6 +42,24 @@ class TestGeokitGeoip < Test::Unit::TestCase
         assert (40..41).include?(loc.lat)
         assert (-74..-73).include?(loc.lng)
         assert_equal 5, loc.zip.size
+      end
+    end
+
+    context "with a good ip that returns ISO-8859-I" do
+      setup { @ip = '66.203.219.253' }
+      should "be successful" do
+        result = @geocoder.geocode(@ip)
+        assert result.success?, result.city
+      end
+      should "set the right attributes (as UTF8)" do
+        loc = @geocoder.geocode(@ip)
+        puts loc.city
+        assert_equal "Linière", loc.city
+        assert_equal "QC", loc.state
+        assert_equal "CA", loc.country_code
+        assert (46..47).include?(loc.lat)
+        assert (-71..-70).include?(loc.lng)
+        assert_equal 0, loc.zip.size
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,3 @@
-require 'test/unit'
-require File.dirname(__FILE__) + '/../lib/geokit-geoip'
+require_relative '../lib/geokit-geoip'
 require 'shoulda'
-require 'ruby-debug'
+require 'minitest/autorun'


### PR DESCRIPTION
Proposed Version 1.0.0:
- replace `debugger` dependency with `byebug`
- require geokit 1.10.0
- replace test::unit with minitest (as per rails 4.*)
- add a test to ensure utf8 strings are returned
